### PR TITLE
Generate plan activities

### DIFF
--- a/api/test_flaskr.py
+++ b/api/test_flaskr.py
@@ -1,0 +1,13 @@
+import os
+import tempfile
+
+import pytest
+
+
+@pytest.fixture
+def client():
+    a=1
+
+
+def test_client(client):
+    assert True

--- a/api/views/athlete.py
+++ b/api/views/athlete.py
@@ -32,9 +32,6 @@ def post_athlete():
                 "access_token": body["access_token"],
                 "refresh_token": body["refresh_token"],
                 "expires_at": convert_iso_to_datetime(body["expires_at"]),
-                "first_name": body["first_name"],
-                "last_name": body["last_name"],
-                "sex": body["sex"],
             }
         },
         upsert=True,

--- a/api/views/plan.py
+++ b/api/views/plan.py
@@ -21,16 +21,16 @@ def get_all_plans(athlete_id):
     """
 
     try:
-        cursor = mongo.db.plans.find({"athlete_id": athlete_id})
+        cursor = mongo.db.plans.find({"athlete_id": athlete_id}).sort('finish_date', 1)
     except Exception as e:
         return "An error occurred when getting athlete's plans", 500
 
-    result = []
-    for doc in cursor:
-        doc["_id"] = str(doc["_id"])
-        result.append(doc)
+    plan_list = []
+    for plan in cursor:
+        plan["_id"] = str(plan["_id"])
+        plan_list.append(plan)
 
-    return {"plans": result}, 200
+    return {"plans": plan_list}, 200
 
 
 @plan.route("/plans/<string:athlete_id>/<string:plan_id>", methods=["GET"])

--- a/api/views/plan.py
+++ b/api/views/plan.py
@@ -6,6 +6,7 @@ from .strava import get_strava_activities
 from .shared import convert_iso_to_date, convert_iso_to_datetime
 import datetime as time
 import math
+from bson import ObjectId
 
 plan = Blueprint("plan", __name__)
 
@@ -31,6 +32,22 @@ def get_all_plans(athlete_id):
     return {"plans": result}, 200
 
 
+@plan.route("/plan/<string:plan_id>", methods=["GET"])
+def get_one_plan(plan_id):
+
+    """
+    This endpoint is used to get the specified training plan selected by the user.
+    """
+
+    plan = mongo.db.plans.find_one({"_id": ObjectId(plan_id)})
+
+    if plan is not None:
+        plan["_id"] = str(plan["_id"])
+        return plan, 200
+    else:
+        return "No plan was found with this ID", 404
+
+
 @plan.route("/plans", methods=["POST"])
 def post_plan():
 
@@ -50,10 +67,10 @@ def post_plan():
 
     body["activities"] = generate_plan_activities(athlete_id, body)
 
-    # try:
-    #     mongo.db.plans.insert_one(body)
-    # except Exception as e:
-    #     return "An error occurred when adding the new plan", 500
+    try:
+        mongo.db.plans.insert_one(body)
+    except Exception as e:
+        return "An error occurred when adding the new plan", 500
 
     return body, 201
 
@@ -129,7 +146,6 @@ def generate_plan_activities(athlete_id, plan):
 
     # Allocate these activities to their appropriate dates, using the preferences set in the plan details 
     plan_activities = allocate_activity_dates(plan_activities, plan)
-    print(insights)
 
     return plan_activities
 
@@ -311,18 +327,24 @@ def generate_c25k_activities():
             "time": "20 Mins",
             "description": "60 seconds running with 90 seconds walking",
             "date": None,
+            "completed": False,
+            "missed": False
         },
         {
             "run_type": "BASE",
             "time": "20 Mins",
             "description": "60 seconds running with 90 seconds walking",
             "date": None,
+            "completed": False,
+            "missed": False
         },
         {
             "run_type": "BASE",
             "time": "20 Mins",
             "description": "60 seconds running with 90 seconds walking",
             "date": None,
+            "completed": False,
+            "missed": False
         },
         # Week 2
         {
@@ -330,18 +352,24 @@ def generate_c25k_activities():
             "time": "20 Mins",
             "description": "90 seconds running with 2 minutes walking",
             "date": None,
+            "completed": False,
+            "missed": False
         },
         {
             "run_type": "BASE",
             "time": "20 Mins",
             "description": "90 seconds running with 2 minutes walking",
             "date": None,
+            "completed": False,
+            "missed": False
         },
         {
             "run_type": "BASE",
             "time": "20 Mins",
             "description": "90 seconds running with 2 minutes walking",
             "date": None,
+            "completed": False,
+            "missed": False
         },
         # Week 3
         {
@@ -349,18 +377,24 @@ def generate_c25k_activities():
             "time": "18 Mins",
             "description": "2x 90 seconds of running, 90 seconds of walking, 3 minutes of running, 3 minutes of walking",
             "date": None,
+            "completed": False,
+            "missed": False
         },
         {
             "run_type": "BASE",
             "time": "18 Mins",
             "description": "2x 90 seconds of running, 90 seconds of walking, 3 minutes of running, 3 minutes of walking",
             "date": None,
+            "completed": False,
+            "missed": False
         },
         {
             "run_type": "BASE",
             "time": "18 Mins",
             "description": "2x 90 seconds of running, 90 seconds of walking, 3 minutes of running, 3 minutes of walking",
             "date": None,
+            "completed": False,
+            "missed": False
         },
         # Week 4
         {
@@ -368,18 +402,24 @@ def generate_c25k_activities():
             "time": "21.5 Mins",
             "description": "3 minutes of running, 90 seconds walking, 5 minutes running, 2 ½ minutes walking, 3 minutes running, 90 seconds walking, 5 minutes running",
             "date": None,
+            "completed": False,
+            "missed": False
         },
         {
             "run_type": "BASE",
             "time": "21.5 Mins",
             "description": "3 minutes of running, 90 seconds walking, 5 minutes running, 2 ½ minutes walking, 3 minutes running, 90 seconds walking, 5 minutes running",
             "date": None,
+            "completed": False,
+            "missed": False
         },
         {
             "run_type": "BASE",
             "time": "21.5 Mins",
             "description": "3 minutes of running, 90 seconds walking, 5 minutes running, 2 ½ minutes walking, 3 minutes running, 90 seconds walking, 5 minutes running",
             "date": None,
+            "completed": False,
+            "missed": False
         },
         # Week 5
         {
@@ -387,18 +427,24 @@ def generate_c25k_activities():
             "time": "21 Mins",
             "description": "5 minutes running, 3 minutes walking, 5 minutes running, 3 minutes walking, 5 minutes running",
             "date": None,
+            "completed": False,
+            "missed": False
         },
         {
             "run_type": "BASE",
             "time": "21 Mins",
             "description": "8 minutes running, 5 minutes walking, 8 minutes running",
             "date": None,
+            "completed": False,
+            "missed": False
         },
         {
             "run_type": "BASE",
             "time": "20 Mins",
             "description": "20 minutes running, with no walking",
             "date": None,
+            "completed": False,
+            "missed": False
         },
         # Week 6
         {
@@ -406,18 +452,24 @@ def generate_c25k_activities():
             "time": "24 Mins",
             "description": "5 minutes running, 3 minutes walking, 8 minutes running, 3 minutes walking, 5 minutes running",
             "date": None,
+            "completed": False,
+            "missed": False
         },
         {
             "run_type": "BASE",
             "time": "23 Mins",
             "description": "10 minutes running, 3 minutes walking, 10 minutes running",
             "date": None,
+            "completed": False,
+            "missed": False
         },
         {
             "run_type": "BASE",
             "time": "25 Mins",
             "description": "25 minutes running, with no walking",
             "date": None,
+            "completed": False,
+            "missed": False
         },
         # Week 7
         {
@@ -425,18 +477,24 @@ def generate_c25k_activities():
             "time": "25 Mins",
             "description": "25 minutes running, with no walking",
             "date": None,
+            "completed": False,
+            "missed": False
         },
         {
             "run_type": "BASE",
             "time": "25 Mins",
             "description": "25 minutes running, with no walking",
             "date": None,
+            "completed": False,
+            "missed": False
         },
         {
             "run_type": "BASE",
             "time": "25 Mins",
             "description": "25 minutes running, with no walking",
             "date": None,
+            "completed": False,
+            "missed": False
         },
         # Week 8
         {
@@ -444,18 +502,24 @@ def generate_c25k_activities():
             "time": "28 Mins",
             "description": "28 minutes running, with no walking",
             "date": None,
+            "completed": False,
+            "missed": False
         },
         {
             "run_type": "BASE",
             "time": "25 Mins",
             "description": "28 minutes running, with no walking",
             "date": None,
+            "completed": False,
+            "missed": False
         },
         {
             "run_type": "BASE",
             "time": "28 Mins",
             "description": "28 minutes running, with no walking",
             "date": None,
+            "completed": False,
+            "missed": False
         },
         # Week 9
         {
@@ -463,18 +527,24 @@ def generate_c25k_activities():
             "time": "30 Mins",
             "description": "28 minutes running, with no walking",
             "date": None,
+            "completed": False,
+            "missed": False
         },
         {
             "run_type": "BASE",
             "time": "30 Mins",
             "description": "30 minutes running, with no walking",
             "date": None,
+            "completed": False,
+            "missed": False
         },
         {
             "run_type": "BASE",
             "time": "30 Mins",
             "description": "30 minutes running, with no walking",
             "date": None,
+            "completed": False,
+            "missed": False
         },
     ]
 

--- a/api/views/plan.py
+++ b/api/views/plan.py
@@ -20,9 +20,9 @@ def post_plan():
 
     if athlete_id:
         if not validate_plan_data(body):
-            return "Error validating athlete's data", 400
+            return "An error occurred when validating the plan details", 400
     else:
-        return "Error obtaining the athlete's id", 400
+        return "An error occurred when getting the athlete's id", 400
 
     body["plan"] = generate_training_plan(athlete_id, body)
 
@@ -117,10 +117,19 @@ def generate_training_plan(athlete_id, plan):
     # Create insights from these activities to help in plan generation
     insights = get_insights(activities)
 
-    plan_length = calculate_plan_length(finish_date, activities)
+    # plan_length = calculate_plan_length(finish_date, activities)
 
     goal_type = plan.get("goal_type")
     if goal_type == "DISTANCE":
+        if distance == "5KM":
+            a = 1
+        elif distance == "10KM":
+            a = 1
+        elif distance == "HALF-MARATHON":
+            a = 1
+        elif distance == "MARATHON":
+            a = 1
+    elif goal_type == "TIME":
         if distance == "5KM":
             a = 1
         elif distance == "10KM":

--- a/api/views/plan.py
+++ b/api/views/plan.py
@@ -57,6 +57,11 @@ def get_one_plan(athlete_id, plan_id):
                 avg_speed += activity["average_speed"]
                 number_of_runs += 1
 
+                # print(type(convert_iso_to_date(activity["start_date"])))
+                # print(type(convert_iso_to_date(plan["start_date"])))
+                if convert_iso_to_date(activity["start_date"]) > convert_iso_to_date(plan["start_date"]):
+                    print("HELLO")
+
                 run_data.append(
                     {
                         "id": activity["id"],
@@ -69,12 +74,12 @@ def get_one_plan(athlete_id, plan_id):
 
         # Calculate current paces and get their string equivalents
         avg_ms = avg_speed / number_of_runs
-        easy_pace = calculate_time_per_km(avg_ms * 1.1)
+        easy_pace = calculate_time_per_km(avg_ms * 0.9)
         steady_pace = calculate_time_per_km(avg_ms)
-        fast_pace = calculate_time_per_km(avg_ms * 0.9)
-        easy_pace_string = get_pace_string(avg_ms * 1.1)
+        fast_pace = calculate_time_per_km(avg_ms * 1.1)
+        easy_pace_string = get_pace_string(avg_ms * 0.9)
         steady_pace_string = get_pace_string(avg_ms)
-        fast_pace_string = get_pace_string(avg_ms * 0.9)
+        fast_pace_string = get_pace_string(avg_ms * 1.1)
 
         for activity in plan["activities"]:
 

--- a/api/views/strava.py
+++ b/api/views/strava.py
@@ -25,7 +25,7 @@ def get_strava_insights():
         return "An error occurred when getting the athlete's id", 400
 
     # Get all athlete activities from strava api
-    activities = get_activities(athlete_id)
+    activities = get_strava_activities(athlete_id)
     if not activities:
         return "An error occurred when requesting the athlete's activities", 500
 
@@ -161,7 +161,7 @@ def get_dashboard_data():
     if not athlete_id:
         return "An error occurred when getting the athlete's id", 400
 
-    activities = get_activities(athlete_id)
+    activities = get_strava_activities(athlete_id)
     if not activities:
         return "An error occurred when requesting the athlete's activities", 500
 
@@ -245,7 +245,7 @@ def get_dashboard_data():
     return {"latest_run": latest_run, "last_week": last_week}, 200
 
 
-def get_activities(athlete_id):
+def get_strava_activities(athlete_id):
 
     """
     Function to call the Strava API and return all the activities the athlete has recorded to date

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1560,6 +1560,11 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.8.4.tgz",
       "integrity": "sha512-h0lY7g36rhjNV8KVHKS3/BEOgfsxu0AiRI8+ry5IFBGEsQFkpjxtcpVc9ndN8zrKUeMZXAWMc7eQMepfgykpxQ=="
     },
+    "@react-leaflet/core": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-1.0.2.tgz",
+      "integrity": "sha512-QbleYZTMcgujAEyWGki8Lx6cXQqWkNtQlqf5c7NImlIp8bKW66bFpez/6EVatW7+p9WKBOEOVci/9W7WW70EZg=="
+    },
     "@restart/hooks": {
       "version": "0.3.26",
       "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.3.26.tgz",
@@ -1863,6 +1868,12 @@
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
       "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag=="
     },
+    "@types/geojson": {
+      "version": "7946.0.7",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.7.tgz",
+      "integrity": "sha512-wE2v81i4C4Ol09RtsWFAqg3BUitWbHSpSlIo+bNdsCJijO9sjme+zm+73ZMCa/qMC8UEERxzGbvmr1cffo2SiQ==",
+      "dev": true
+    },
     "@types/glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
@@ -1898,6 +1909,15 @@
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
       "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ=="
+    },
+    "@types/leaflet": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.7.0.tgz",
+      "integrity": "sha512-ltv5jR+VjKSMtoDkxH61Rsbo0zLU7iqyOXpVPkAX4F+79fg2eymC7t0msWsfNaEZO1FGTIQATCCCQe+ijWoicg==",
+      "dev": true,
+      "requires": {
+        "@types/geojson": "*"
+      }
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -5067,23 +5087,23 @@
       "integrity": "sha512-YqAL+NXOzjBnpY+dcOKDlZybJDCOzgsq4koW3fvyty/ldTmsb4QazZpOWmVvZ2m0t5jbBf7L0lIGU3BUipwG+A=="
     },
     "elliptic": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
       "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
         "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.11.9",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         }
       }
     },
@@ -8293,6 +8313,11 @@
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
     },
+    "leaflet": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.7.1.tgz",
+      "integrity": "sha512-/xwPEBidtg69Q3HlqPdU3DnrXQOvQU/CCHA1tcDQVzOwm91YMYaILjNp7L4Eaw5Z4sOYdbBz6koWyibppd8Zqw=="
+    },
     "left-pad": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
@@ -11283,9 +11308,9 @@
       }
     },
     "react": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
-      "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -11547,9 +11572,9 @@
       }
     },
     "react-dom": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
-      "integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -11575,6 +11600,14 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "react-leaflet": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-3.1.0.tgz",
+      "integrity": "sha512-kdZS8NYbYFPmkQr7zSDR2gkKGFeWvkxqoqcmZEckzHL4d5c85dJ2gbbqhaPDpmWWgaRw9O29uA/77qpKmK4mTQ==",
+      "requires": {
+        "@react-leaflet/core": "^1.0.2"
+      }
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",
@@ -14843,9 +14876,9 @@
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ=="
     },
     "yallist": {
       "version": "4.0.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1555,6 +1555,27 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
     },
+    "@popperjs/core": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.8.4.tgz",
+      "integrity": "sha512-h0lY7g36rhjNV8KVHKS3/BEOgfsxu0AiRI8+ry5IFBGEsQFkpjxtcpVc9ndN8zrKUeMZXAWMc7eQMepfgykpxQ=="
+    },
+    "@restart/hooks": {
+      "version": "0.3.26",
+      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.3.26.tgz",
+      "integrity": "sha512-7Hwk2ZMYm+JLWcb7R9qIXk1OoUg1Z+saKWqZXlrvFwT3w6UArVNWgxYOzf+PJoK9zZejp8okPAKTctthhXLt5g==",
+      "requires": {
+        "lodash": "^4.17.20",
+        "lodash-es": "^4.17.20"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        }
+      }
+    },
     "@sheerun/mutationobserver-shim": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz",
@@ -2036,6 +2057,11 @@
           }
         }
       }
+    },
+    "@types/warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.0.tgz",
+      "integrity": "sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI="
     },
     "@types/yargs": {
       "version": "13.0.10",
@@ -4592,6 +4618,11 @@
         }
       }
     },
+    "date-arithmetic": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-arithmetic/-/date-arithmetic-4.1.0.tgz",
+      "integrity": "sha512-QWxYLR5P/6GStZcdem+V1xoto6DMadYWpMXU82ES3/RfR3Wdwr3D0+be7mgOJ+Ov0G9D5Dmb9T17sNLQYj9XOg=="
+    },
     "date-fns": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.16.1.tgz",
@@ -7022,9 +7053,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "inquirer": {
       "version": "7.3.3",
@@ -8390,6 +8421,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+    },
     "lodash._reinterpolate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
@@ -8554,6 +8590,11 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "memoize-one": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
+      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
     },
     "memory-fs": {
       "version": "0.4.1",
@@ -11264,6 +11305,24 @@
         "whatwg-fetch": "^3.0.0"
       }
     },
+    "react-big-calendar": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/react-big-calendar/-/react-big-calendar-0.32.0.tgz",
+      "integrity": "sha512-IidodG2oCd9VH7f9AsZAMyPZw12wLoicjHzEECrqdg3PIOuKOTScYhsqrSdNq+5j3vfy5sby5cWdBxgViMz9Mg==",
+      "requires": {
+        "@babel/runtime": "^7.1.5",
+        "clsx": "^1.0.4",
+        "date-arithmetic": "^4.0.1",
+        "dom-helpers": "^5.1.0",
+        "invariant": "^2.2.4",
+        "lodash": "^4.17.11",
+        "lodash-es": "^4.17.11",
+        "memoize-one": "^5.1.1",
+        "prop-types": "^15.7.2",
+        "react-overlays": "^4.1.1",
+        "uncontrollable": "^7.0.0"
+      }
+    },
     "react-calendar": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/react-calendar/-/react-calendar-3.1.0.tgz",
@@ -11521,6 +11580,31 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-overlays": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-4.1.1.tgz",
+      "integrity": "sha512-WtJifh081e6M24KnvTQoNjQEpz7HoLxqt8TwZM7LOYIkYJ8i/Ly1Xi7RVte87ZVnmqQ4PFaFiNHZhSINPSpdBQ==",
+      "requires": {
+        "@babel/runtime": "^7.12.1",
+        "@popperjs/core": "^2.5.3",
+        "@restart/hooks": "^0.3.25",
+        "@types/warning": "^3.0.0",
+        "dom-helpers": "^5.2.0",
+        "prop-types": "^15.7.2",
+        "uncontrollable": "^7.0.0",
+        "warning": "^4.0.3"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.7",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.7.tgz",
+          "integrity": "sha512-h+ilqoX998mRVM5FtB5ijRuHUDVt5l3yfoOi2uh18Z/O3hvyaHQ39NpxVkCIG5yFs+mLq/ewFp8Bss6zmWv6ZA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
     },
     "react-resize-detector": {
       "version": "2.3.0",
@@ -13647,6 +13731,17 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "uncontrollable": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-7.2.1.tgz",
+      "integrity": "sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==",
+      "requires": {
+        "@babel/runtime": "^7.6.3",
+        "@types/react": ">=16.9.11",
+        "invariant": "^2.2.4",
+        "react-lifecycles-compat": "^3.0.4"
+      }
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "moment": "^2.29.0",
     "node-forge": "^0.10.0",
     "react": "^16.13.1",
+    "react-big-calendar": "^0.32.0",
     "react-date-picker": "^8.0.3",
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,12 +14,14 @@
     "axios": "^0.21.1",
     "dotenv": "^8.2.0",
     "http-proxy": "^1.18.1",
+    "leaflet": "^1.7.1",
     "moment": "^2.29.0",
     "node-forge": "^0.10.0",
-    "react": "^16.13.1",
+    "react": "^16.14.0",
     "react-big-calendar": "^0.32.0",
     "react-date-picker": "^8.0.3",
-    "react-dom": "^16.13.1",
+    "react-dom": "^16.14.0",
+    "react-leaflet": "^3.1.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "^3.4.3",
     "recharts": "^1.8.5",
@@ -47,5 +49,8 @@
       "last 1 safari version"
     ]
   },
-  "proxy": "http://localhost:5000"
+  "proxy": "http://localhost:5000",
+  "devDependencies": {
+    "@types/leaflet": "^1.7.0"
+  }
 }

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -3,6 +3,12 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"
+      integrity="sha512-xodZBNTC5n17Xt2atTPuE1HxjVMSvLVW9ocqUKLsCC5CXdbqCmblAshOMAS6/keqq/sMZMZ19scR4PsZChSR7A=="
+      crossorigin=""
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta
@@ -24,7 +30,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    
+
     <title>Talaria</title>
   </head>
   <body>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -3,3 +3,8 @@
 .ant-picker-dropdown {
     z-index: 10000 !important
 }
+
+.leaflet-container{
+    width: 30vw;
+    height: 40vh;
+}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2,6 +2,7 @@ import React from "react";
 import "./App.css";
 import Dashboard from "./Dashboard/DashboardWrapper";
 import LogIn from "./LogIn/LogIn";
+import ViewPlan from "./ViewPlan/ViewPlan";
 import { Switch, Route } from "react-router-dom";
 import CreatePlan from "./CreatePlan/CreatePlanWrapper";
 import NotFound from "./assets/js/NotFound";
@@ -18,6 +19,7 @@ function App() {
           <Route exact path={urls.Login} component={LogIn} />
           <Route exact path={urls.Dashboard} component={Dashboard} />
           <Route exact path={urls.CreatePlan} component={CreatePlan} />
+          <Route exact path={urls.ViewPlan} component={ViewPlan} />
 
           {/* 404 page if the url doesn't match any of the URLs */}
           <Route component={NotFound} />

--- a/frontend/src/CreatePlan/Components/CreatePlan.js
+++ b/frontend/src/CreatePlan/Components/CreatePlan.js
@@ -164,6 +164,9 @@ export default function CreatePlan() {
   }
 
   const handleSubmit = () => {
+    const body = document.querySelector("#root");
+    body.scrollIntoView();
+    
     const plan_data = {
       athlete_id: sessionStorage.athleteID,
       distance: state.distance,

--- a/frontend/src/CreatePlan/Components/CreatePlan.js
+++ b/frontend/src/CreatePlan/Components/CreatePlan.js
@@ -85,6 +85,9 @@ const useStyles = makeStyles((theme) => ({
     marginRight: theme.spacing(2),
     color: "orange",
   },
+  warningColor: {
+    backgroundColor: "rgb(255, 244, 229)",
+  },
 }));
 
 const steps = [

--- a/frontend/src/CreatePlan/Components/CreatePlan.js
+++ b/frontend/src/CreatePlan/Components/CreatePlan.js
@@ -169,6 +169,7 @@ export default function CreatePlan({ athleteID }) {
       distance: state.distance,
       goal_type: state.goalType,
       goal_time: state.goalTime,
+      start_date: state.startDate,
       finish_date: state.finishDate,
       runs_per_week: state.runsPerWeek,
       include_taper: state.includeTaper,
@@ -182,6 +183,7 @@ export default function CreatePlan({ athleteID }) {
       .post(urls.Plans, plan_data, {})
       .then((response) => {
         setState({ ...state, planSubmitted: true, planSubmittedError: false });
+        console.log(response.data)
       })
       .catch((error) => {
         console.error("Error while posting plan details");
@@ -302,11 +304,11 @@ export default function CreatePlan({ athleteID }) {
                 color="primary"
                 onClick={state.step === 5 ? handleSubmit : handleNext}
                 className={classes.button}
-                disabled={
-                  state.planSubmitted &&
-                  !state.planSubmittedError &&
-                  state.step === steps.length - 1
-                }
+                // disabled={
+                //   state.planSubmitted &&
+                //   !state.planSubmittedError &&
+                //   state.step === steps.length - 1
+                // }
               >
                 {state.step === steps.length - 1 ? "Create Plan" : "Next"}
               </Button>

--- a/frontend/src/CreatePlan/Components/CreatePlan.js
+++ b/frontend/src/CreatePlan/Components/CreatePlan.js
@@ -183,7 +183,7 @@ export default function CreatePlan() {
       .post(urls.Plans, plan_data, {})
       .then((response) => {
         setState({ ...state, planSubmitted: true, planSubmittedError: false });
-        console.log(response.data)
+        sessionStorage.setItem("planID", response.data)
       })
       .catch((error) => {
         console.error("Error while posting plan details");
@@ -328,7 +328,7 @@ export default function CreatePlan() {
         </Dialog>
       )}
 
-      {/* Dialog box for insights loading */}
+      {/* Dialog box for insights loading error */}
       {loadingError && (
         <Dialog
           open={loadingError}

--- a/frontend/src/CreatePlan/Components/CreatePlan.js
+++ b/frontend/src/CreatePlan/Components/CreatePlan.js
@@ -103,7 +103,7 @@ const Transition = React.forwardRef(function Transition(props, ref) {
   return <Slide direction="up" ref={ref} {...props} />;
 });
 
-export default function CreatePlan({ athleteID }) {
+export default function CreatePlan() {
   const classes = useStyles();
   const LinkRouter = (props) => <Link {...props} component={RouterLink} />;
 
@@ -128,7 +128,7 @@ export default function CreatePlan({ athleteID }) {
      provide personalised suggestions
     */
     axios
-      .get(urls.StravaInsights, { params: { athlete_id: athleteID } })
+      .get(urls.StravaInsights, { params: { athlete_id: sessionStorage.athleteID } })
       .then((response) => {
         setLoading(false);
         const runsPerWeek = getRunsPerWeek(response.data["runs_per_week"]);
@@ -165,7 +165,7 @@ export default function CreatePlan({ athleteID }) {
 
   const handleSubmit = () => {
     const plan_data = {
-      athlete_id: athleteID,
+      athlete_id: sessionStorage.athleteID,
       distance: state.distance,
       goal_type: state.goalType,
       goal_time: state.goalTime,
@@ -256,7 +256,6 @@ export default function CreatePlan({ athleteID }) {
           color="inherit"
           to={{
             pathname: urls.Dashboard,
-            state: { athleteID: athleteID },
           }}
         >
           Home
@@ -345,7 +344,6 @@ export default function CreatePlan({ athleteID }) {
             <LinkRouter
               to={{
                 pathname: urls.Dashboard,
-                state: { athleteID: athleteID },
               }}
             >
               <Button

--- a/frontend/src/CreatePlan/Components/Preferences.js
+++ b/frontend/src/CreatePlan/Components/Preferences.js
@@ -182,6 +182,7 @@ export default function PreferencesForm() {
           className={classes.input}
           value={state.planName}
           onChange={(e) => setState({ ...state, planName: e.target.value })}
+          inputProps={{ maxLength: 50 }}
         />
         <Typography className={classes.info}>
           Is there any particular days you'd not like to run on during the plan?

--- a/frontend/src/CreatePlan/Components/Summary.js
+++ b/frontend/src/CreatePlan/Components/Summary.js
@@ -9,6 +9,8 @@ import Alert from "@material-ui/lab/Alert";
 import { Typography } from "@material-ui/core";
 import * as enums from "../../assets/utils/enums";
 import Button from "@material-ui/core/Button";
+import Link from "@material-ui/core/Link";
+import * as urls from "../../assets/utils/urls";
 
 const useStyles = makeStyles((theme) => ({
   capitalize: {
@@ -37,7 +39,11 @@ export default function Summary() {
     <React.Fragment>
       {state.planSubmitted && (
         <Alert severity="success" className={classes.info}>
-          SUCCESS: Your plan was created successfully!
+          SUCCESS: Your plan was created successfully! Click{" "}
+          <Link href={urls.ViewPlan}>
+            here
+          </Link>{" "}
+          to view it.
         </Alert>
       )}
       {state.planSubmittedError && (

--- a/frontend/src/CreatePlan/CreatePlanWrapper.js
+++ b/frontend/src/CreatePlan/CreatePlanWrapper.js
@@ -10,10 +10,10 @@ export default function CreatePlanWrapper(props) {
 
   return (
     <React.Fragment>
-      {props.location.state ? (
+      {sessionStorage.athleteID ? (
         <CreatePlanProvider>
           <React.Fragment>
-            <CreatePlan athleteID={props.location.state.athleteID} />
+            <CreatePlan />
           </React.Fragment>
         </CreatePlanProvider>
       ) : (

--- a/frontend/src/Dashboard/Components/Dashboard.js
+++ b/frontend/src/Dashboard/Components/Dashboard.js
@@ -58,7 +58,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export default function Dashboard({ athleteID }) {
+export default function Dashboard() {
   const classes = useStyles();
   const fixedHeightPaper = clsx(classes.paper, classes.fixedHeight);
 
@@ -75,7 +75,7 @@ export default function Dashboard({ athleteID }) {
   useEffect(() => {
     // On initial loading of the Dashboard, we request the user's plans and an insight into their recent Strava activity
     axios
-      .get(`${urls.Plans}/${athleteID}`, {})
+      .get(`${urls.Plans}/${sessionStorage.athleteID}`, {})
       .then((response) => {
         setPlans(response.data["plans"]);
       })
@@ -85,7 +85,7 @@ export default function Dashboard({ athleteID }) {
       });
 
     axios
-      .get(urls.DashboardActivities, { params: { athlete_id: athleteID } })
+      .get(urls.DashboardActivities, { params: { athlete_id: sessionStorage.athleteID } })
       .then((response) => {
         setDashboardStrava({
           ...dashboardStrava,
@@ -125,10 +125,10 @@ export default function Dashboard({ athleteID }) {
         <Redirect
           to={{
             pathname: urls.CreatePlan,
-            state: { athleteID: athleteID },
+            state: { athleteID: sessionStorage.athleteID },
           }}
         />
-      )}
+      )} 
       <Header connectToStrava={false} />
       <CssBaseline />
       <main className={classes.layout}>

--- a/frontend/src/Dashboard/Components/Dashboard.js
+++ b/frontend/src/Dashboard/Components/Dashboard.js
@@ -16,7 +16,6 @@ import * as urls from "../../assets/utils/urls";
 import { Redirect } from "react-router-dom";
 import axios from "axios";
 import { DashboardContext } from "../DashboardContext";
-import Typography from "@material-ui/core/Typography";
 import Tooltip from "@material-ui/core/Tooltip";
 
 const useStyles = makeStyles((theme) => ({

--- a/frontend/src/Dashboard/Components/Plans.js
+++ b/frontend/src/Dashboard/Components/Plans.js
@@ -8,8 +8,6 @@ import Paper from "@material-ui/core/Paper";
 import Typography from "@material-ui/core/Typography";
 import * as enums from "../../assets/utils/enums";
 import CircularProgress from "@material-ui/core/CircularProgress";
-import * as urls from "../../assets/utils/urls";
-import { Redirect } from "react-router-dom";
 
 const useStyles = makeStyles((theme) => ({
   seeMore: {

--- a/frontend/src/Dashboard/Components/Plans.js
+++ b/frontend/src/Dashboard/Components/Plans.js
@@ -9,9 +9,9 @@ import Typography from "@material-ui/core/Typography";
 import * as enums from "../../assets/utils/enums";
 import CircularProgress from "@material-ui/core/CircularProgress";
 
-function preventDefault(event) {
-  event.preventDefault();
-}
+// function preventDefault(event) {
+//   event.preventDefault();
+// }
 
 const useStyles = makeStyles((theme) => ({
   seeMore: {
@@ -71,7 +71,9 @@ export default function Plans() {
                 </Typography>
 
                 <div className={classes.seeMore}>
-                  <Link color="primary" href="#" onClick={preventDefault}>
+                  <Link color="primary" href="/view-plan" 
+                  // onClick={preventDefault}
+                  >
                     View Plan
                   </Link>
                 </div>

--- a/frontend/src/Dashboard/Components/Plans.js
+++ b/frontend/src/Dashboard/Components/Plans.js
@@ -7,7 +7,7 @@ import Grid from "@material-ui/core/Grid";
 import Paper from "@material-ui/core/Paper";
 import Typography from "@material-ui/core/Typography";
 import * as enums from "../../assets/utils/enums";
-import CircularProgress from "@material-ui/core/CircularProgress";
+import * as urls from "../../assets/utils/urls";
 
 const useStyles = makeStyles((theme) => ({
   seeMore: {
@@ -30,6 +30,9 @@ const useStyles = makeStyles((theme) => ({
     marginLeft: "auto",
     marginRight: "auto",
   },
+  noPlans: {
+    textAlign: "center"
+  }
 }));
 
 export default function Plans() {
@@ -40,15 +43,16 @@ export default function Plans() {
 
   return (
     <React.Fragment>
-      {state.dashboardError ? (
+      <Typography component="p" variant="h5" className={classes.divider}>
+        Training Plans
+      </Typography>
+      {state.dashboardError && (
         <Typography component="p" color="textSecondary">
           There was an error getting your training plans
         </Typography>
-      ) : state.plans ? (
+      )}
+      {state.plans && (
         <>
-          <Typography component="p" variant="h5" className={classes.divider}>
-            Training Plans
-          </Typography>
           {state.plans.map((plan) => (
             <Grid key={plan._id} item xs={12}>
               <Paper className={classes.paper}>
@@ -79,8 +83,15 @@ export default function Plans() {
             </Grid>
           ))}
         </>
-      ) : (
-        <CircularProgress color="secondary" className={classes.loading} />
+      )}
+      {state.plans.length === 0 && (
+        <Grid key={1} item xs={12}>
+          <Typography className={classes.noPlans} color="textSecondary">
+            Sorry! You don't seem to have any plans created. Click{" "}<Link href={urls.CreatePlan}>
+            here
+          </Link>{" "}to get started.
+          </Typography>
+        </Grid>
       )}
     </React.Fragment>
   );

--- a/frontend/src/Dashboard/Components/Plans.js
+++ b/frontend/src/Dashboard/Components/Plans.js
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useContext, useState } from "react";
 import Link from "@material-ui/core/Link";
 import { makeStyles } from "@material-ui/core/styles";
 import Title from "./Title";
@@ -8,10 +8,8 @@ import Paper from "@material-ui/core/Paper";
 import Typography from "@material-ui/core/Typography";
 import * as enums from "../../assets/utils/enums";
 import CircularProgress from "@material-ui/core/CircularProgress";
-
-// function preventDefault(event) {
-//   event.preventDefault();
-// }
+import * as urls from "../../assets/utils/urls";
+import { Redirect } from "react-router-dom";
 
 const useStyles = makeStyles((theme) => ({
   seeMore: {
@@ -33,7 +31,7 @@ const useStyles = makeStyles((theme) => ({
   divider: {
     marginLeft: "auto",
     marginRight: "auto",
-  }
+  },
 }));
 
 export default function Plans() {
@@ -71,9 +69,7 @@ export default function Plans() {
                 </Typography>
 
                 <div className={classes.seeMore}>
-                  <Link color="primary" href="/view-plan" 
-                  // onClick={preventDefault}
-                  >
+                  <Link color="primary" href="/view-plan">
                     View Plan
                   </Link>
                 </div>

--- a/frontend/src/Dashboard/Components/Plans.js
+++ b/frontend/src/Dashboard/Components/Plans.js
@@ -69,7 +69,11 @@ export default function Plans() {
                 </Typography>
 
                 <div className={classes.seeMore}>
-                  <Link color="primary" href="/view-plan">
+                  <Link
+                    color="primary"
+                    href="/view-plan"
+                    onClick={(e) => sessionStorage.setItem("planID", plan._id)}
+                  >
                     View Plan
                   </Link>
                 </div>

--- a/frontend/src/Dashboard/Components/RecentRun.js
+++ b/frontend/src/Dashboard/Components/RecentRun.js
@@ -42,7 +42,7 @@ export default function RecentRun() {
           <List>
             <ListItem>
               <ListItemText
-                primary={state.recentRun["distance"] + "km"}
+                primary={state.recentRun["distance"] + "KM"}
                 secondary="Distance"
               />
               <ListItemText

--- a/frontend/src/Dashboard/DashboardWrapper.js
+++ b/frontend/src/Dashboard/DashboardWrapper.js
@@ -9,10 +9,10 @@ export default function DashboardWrapper(props) {
   // it also provides the components within it access to the DashboardContext
   return (
     <React.Fragment>
-      {props.location.state ? (
+      {sessionStorage.athleteID ? (
         <DashboardProvider>
           <React.Fragment>
-            <Dashboard athleteID={props.location.state.athleteID} />
+            <Dashboard />
           </React.Fragment>
         </DashboardProvider>
       ) : (

--- a/frontend/src/ViewPlan/ViewPlan.js
+++ b/frontend/src/ViewPlan/ViewPlan.js
@@ -1,0 +1,47 @@
+import React, { Component } from "react";
+import { Calendar, momentLocalizer } from "react-big-calendar";
+import moment from "moment";
+import "react-big-calendar/lib/css/react-big-calendar.css";
+import Header from "../assets/js/Header";
+
+const localizer = momentLocalizer(moment);
+
+const now = new Date();
+const events = [
+  {
+    id: 0,
+    title: "All Day Event very long title",
+    allDay: true,
+    start: new Date(2019, 6, 0),
+    end: new Date(2019, 6, 1),
+  },
+  {
+    id: 1,
+    title: "Long Event",
+    start: new Date(2019, 3, 7),
+    end: new Date(2019, 3, 10),
+  },
+  {
+    id: 2,
+    title: "Right now Time Event",
+    start: now,
+    end: now,
+  },
+];
+
+export default function ViewPlan() {
+  return (
+    <React.Fragment>
+      <Header connectToStrava={false} />
+      <div style={{ height: "500pt" }}>
+        <Calendar
+          events={events}
+          startAccessor="start"
+          endAccessor="end"
+          defaultDate={moment().toDate()}
+          localizer={localizer}
+        />
+      </div>
+    </React.Fragment>
+  );
+}

--- a/frontend/src/ViewPlan/ViewPlan.js
+++ b/frontend/src/ViewPlan/ViewPlan.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { Component, useState, useEffect, useContext } from "react";
 import { Calendar, momentLocalizer } from "react-big-calendar";
 import moment from "moment";
 import "react-big-calendar/lib/css/react-big-calendar.css";
@@ -10,6 +10,7 @@ import * as urls from "../assets/utils/urls";
 import Breadcrumbs from "@material-ui/core/Breadcrumbs";
 import Link from "@material-ui/core/Link";
 import { Link as RouterLink } from "react-router-dom";
+import axios from "axios";
 
 const localizer = momentLocalizer(moment);
 
@@ -43,9 +44,31 @@ const events = [
   },
 ];
 
+// class EventComponent extends React.Component {
+//   render() {
+//     return <h1>here we go!</h1>
+//   }
+// }
+
 export default function ViewPlan() {
   const classes = useStyles();
   const LinkRouter = (props) => <Link {...props} component={RouterLink} />;
+
+  useEffect(() => {
+    /*
+     On entry to CreatePlan, we get our list of strava insights to be used throughout plan creation to
+     provide personalised suggestions
+    */
+    axios
+      .get(urls.Plan + "/" + sessionStorage.planID )
+      .then((response) => {
+        console.log(response.data)
+      })
+      .catch((error) => {
+        console.log(error);
+      });
+  }, []);
+
   return (
     <React.Fragment>
       <Header connectToStrava={false} />
@@ -67,7 +90,7 @@ export default function ViewPlan() {
           View Plan
         </Typography>
       </Breadcrumbs>
-      <div style={{ height: "500pt", marginTop: "10px" }}>
+      <div style={{ height: "500pt", margin: "20px" }}>
         <Calendar
           events={events}
           startAccessor="start"
@@ -75,8 +98,13 @@ export default function ViewPlan() {
           defaultDate={moment().toDate()}
           localizer={localizer}
           views={["month", "week"]}
+          // popup={true}
+          // components={{
+          //   event: EventComponent
+          // }}
         />
       </div>
+      <Footer />
     </React.Fragment>
   );
 }

--- a/frontend/src/ViewPlan/ViewPlan.js
+++ b/frontend/src/ViewPlan/ViewPlan.js
@@ -6,68 +6,290 @@ import Header from "../assets/js/Header";
 import { makeStyles } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";
 import Footer from "../assets/js/Footer";
+import * as enums from "../assets/utils/enums";
 import * as urls from "../assets/utils/urls";
 import Breadcrumbs from "@material-ui/core/Breadcrumbs";
 import Link from "@material-ui/core/Link";
 import { Link as RouterLink } from "react-router-dom";
 import axios from "axios";
+import CircularProgress from "@material-ui/core/CircularProgress";
+import Dialog from "@material-ui/core/Dialog";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogTitle from "@material-ui/core/DialogTitle";
+import Slide from "@material-ui/core/Slide";
+import Button from "@material-ui/core/Button";
+import Card from "@material-ui/core/Card";
+import CardHeader from "@material-ui/core/CardHeader";
+import CardContent from "@material-ui/core/CardContent";
+import IconButton from "@material-ui/core/IconButton";
+import DeleteOutlinedIcon from "@material-ui/icons/DeleteOutlined";
+import DialogActions from "@material-ui/core/DialogActions";
+import WarningRoundedIcon from "@material-ui/icons/WarningRounded";
+import Alert from "@material-ui/lab/Alert";
+import Grid from "@material-ui/core/Grid";
+import { MapContainer, TileLayer, Marker, Polyline } from "react-leaflet";
+import CloseIcon from "@material-ui/icons/Close";
 
 const localizer = momentLocalizer(moment);
 
+const Transition = React.forwardRef(function Transition(props, ref) {
+  return <Slide direction="up" ref={ref} {...props} />;
+});
+
 const useStyles = makeStyles((theme) => ({
+  root: {
+    flexGrow: 1,
+  },
+  paper: {
+    padding: theme.spacing(1),
+    // textAlign: "center",
+    // color: theme.palette.text.secondary,
+  },
+  icon: {
+    verticalAlign: "text-bottom",
+    marginRight: theme.spacing(2),
+    color: "orange",
+  },
+  warningColor: {
+    backgroundColor: "rgb(255, 244, 229)",
+  },
   breadcrumb: {
     paddingLeft: theme.spacing(2),
     paddingTop: theme.spacing(1),
   },
+  load: {
+    margin: "auto",
+    marginLeft: theme.spacing(18),
+    marginBottom: theme.spacing(3),
+  },
+  error: {
+    display: "flex",
+    marginLeft: "auto",
+    paddingRight: theme.spacing(2),
+  },
+  padding: {
+    marginBottom: theme.spacing(2),
+  },
+  closeButton: {
+    position: "absolute",
+    right: theme.spacing(1),
+    top: theme.spacing(1),
+    color: theme.palette.grey[500],
+  },
 }));
 
 const now = new Date();
-const events = [
-  {
-    id: 0,
-    title: "All Day Event very long title",
-    allDay: true,
-    start: new Date(2019, 6, 0),
-    end: new Date(2019, 6, 1),
-  },
-  {
-    id: 1,
-    title: "Long Event",
-    start: new Date(2019, 3, 7),
-    end: new Date(2019, 3, 10),
-  },
-  {
-    id: 2,
-    title: "Right now Time Event",
-    start: now,
-    end: now,
-  },
-];
-
-// class EventComponent extends React.Component {
-//   render() {
-//     return <h1>here we go!</h1>
-//   }
-// }
+let activityEvents = [];
 
 export default function ViewPlan() {
   const classes = useStyles();
   const LinkRouter = (props) => <Link {...props} component={RouterLink} />;
 
+  const [plan, setPlan] = useState();
+  const [actEvents, setActivityEvents] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [loadingError, setLoadingError] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [deleteStatus, setDeleteStatus] = useState("");
+  const [selectedActivity, setSelectedActivity] = useState();
+
+  // get plan data
   useEffect(() => {
-    /*
-     On entry to CreatePlan, we get our list of strava insights to be used throughout plan creation to
-     provide personalised suggestions
-    */
     axios
-      .get(urls.Plan + "/" + sessionStorage.planID )
+      .get(
+        urls.Plans +
+          "/" +
+          sessionStorage.athleteID +
+          "/" +
+          sessionStorage.planID
+      )
       .then((response) => {
-        console.log(response.data)
+        console.log(response.data);
+        setLoading(false);
+        setPlan(response.data);
       })
       .catch((error) => {
         console.log(error);
+        setLoadingError(true);
+        setLoading(false);
       });
   }, []);
+
+  // for each activity of the plan, create an event object to be displayed
+  useEffect(() => {
+    console.log(plan);
+    if (plan) {
+      plan.activities.forEach(createEvent);
+    }
+  }, [plan]);
+
+  function createEvent(item, index) {
+    const activityDate = new Date(item.date).toISOString();
+
+    if (index === 0) {
+      activityEvents.push({
+        title: "Plan Start",
+        allDay: true,
+        start: activityDate,
+        end: activityDate,
+        milestone: true,
+      });
+    } else if (index + 1 === plan.activities.length) {
+      activityEvents.push({
+        title: "Plan Finish",
+        allDay: true,
+        start: activityDate,
+        end: activityDate,
+        milestone: true,
+      });
+    }
+
+    activityEvents.push({
+      id: index + 1,
+      title: capitalize(item.run_type) + " Run",
+      allDay: true,
+      start: activityDate,
+      end: activityDate,
+      completed: item.completed,
+      missed: item.missed,
+      description: item.description,
+      time: item.time,
+      run_type: item.run_type,
+      polyline: decode(item.polyline),
+      start_coord: item.start_coord,
+      end_coord: item.end_coord,
+      milestone: false,
+    });
+
+    setActivityEvents(activityEvents);
+  }
+
+  function capitalize(str) {
+    const lower = str.toLowerCase();
+    return str.charAt(0).toUpperCase() + lower.slice(1);
+  }
+
+  const customDayPropGetter = (date) => {
+    const calDate = date.setHours(0, 0, 0, 0);
+    const nowDate = now.setHours(0, 0, 0, 0);
+
+    if (calDate == nowDate)
+      return {
+        className: "special-day",
+        style: {
+          border: "solid 2px #f50057",
+        },
+      };
+    else return {};
+  };
+
+  function eventStyleGetter(event) {
+    var backgroundColor = "#8884D8";
+    if (event.milestone) {
+      backgroundColor = "#f5568d";
+    } else {
+      // change color of event dependant on if its completion status
+      if (event.missed == true) {
+        backgroundColor = "#f26666";
+      } else if (event.completed) {
+        backgroundColor = "#afa";
+      }
+    }
+
+    var style = {
+      backgroundColor: backgroundColor,
+      borderColor: "black",
+      color: "black",
+      border: "1px solid black",
+    };
+    return {
+      style: style,
+    };
+  }
+
+  const onErrorClick = () => {
+    window.location.href = "/";
+  };
+
+  function Event({ event }) {
+    if (!event.milestone) {
+      return (
+        <span>
+          <strong>Activity {event.id}: </strong> {event.title}
+        </span>
+      );
+    } else {
+      return (
+        <span>
+          <strong>{event.title}</strong>
+        </span>
+      );
+    }
+  }
+
+  // source: http://doublespringlabs.blogspot.com.br/2012/11/decoding-polylines-from-google-maps.html
+  // decode function to convert encoded polyline from Strava API to latlong pairs to output route of activity
+  function decode(encoded) {
+    // array that holds the points
+    var points = [];
+    var index = 0,
+      len = encoded.length;
+    var lat = 0,
+      lng = 0;
+    while (index < len) {
+      var b,
+        shift = 0,
+        result = 0;
+      do {
+        b = encoded.charAt(index++).charCodeAt(0) - 63; //finds ascii                                                                                    //and substract it by 63
+        result |= (b & 0x1f) << shift;
+        shift += 5;
+      } while (b >= 0x20);
+
+      var dlat = (result & 1) != 0 ? ~(result >> 1) : result >> 1;
+      lat += dlat;
+      shift = 0;
+      result = 0;
+      do {
+        b = encoded.charAt(index++).charCodeAt(0) - 63;
+        result |= (b & 0x1f) << shift;
+        shift += 5;
+      } while (b >= 0x20);
+      var dlng = (result & 1) != 0 ? ~(result >> 1) : result >> 1;
+      lng += dlng;
+
+      points.push({ lat: lat / 1e5, lng: lng / 1e5 });
+    }
+    return points;
+  }
+
+  const handleCancel = () => {
+    setShowDeleteModal(false);
+  };
+
+  const handleDelete = () => {
+    axios
+      .delete(urls.Plans + "/" + sessionStorage.planID)
+      .then((response) => {
+        setDeleteStatus("DELETED");
+        setShowDeleteModal(false);
+      })
+      .catch((error) => {
+        console.log(error);
+        setDeleteStatus("ERROR");
+        setShowDeleteModal(false);
+      });
+  };
+
+  const handleActivityClose = () => {
+    setSelectedActivity();
+  };
+
+  function onEventSelect(event) {
+    if (!event.milestone) {
+      setSelectedActivity(event)
+    }
+  }
 
   return (
     <React.Fragment>
@@ -79,6 +301,7 @@ export default function ViewPlan() {
       >
         <LinkRouter
           color="inherit"
+          onClick={(e) => sessionStorage.removeItem("planID")}
           to={{
             pathname: urls.Dashboard,
             state: { athleteID: sessionStorage.athleteID },
@@ -90,21 +313,369 @@ export default function ViewPlan() {
           View Plan
         </Typography>
       </Breadcrumbs>
-      <div style={{ height: "500pt", margin: "20px" }}>
+      <div style={{ height: "500pt", margin: "50px" }}>
+        {deleteStatus === "DELETED" && (
+          <Alert severity="error" className={classes.padding}>
+            This plan has been deleted. Click{" "}
+            <LinkRouter
+              to={{
+                pathname: urls.Dashboard,
+              }}
+            >
+              here
+            </LinkRouter>{" "}
+            to return to your Dashboard.
+          </Alert>
+        )}
+        {deleteStatus === "ERROR" && (
+          <Alert severity="error" className={classes.padding}>
+            ERROR: There was a problem when deleting your plan
+          </Alert>
+        )}
+        {plan && (
+          <Card className={classes.padding} variant="outlined">
+            <CardHeader
+              action={
+                <IconButton
+                  aria-label="delete-plan"
+                  onClick={(e) => setShowDeleteModal(true)}
+                >
+                  <DeleteOutlinedIcon color="secondary" />
+                </IconButton>
+              }
+              title={plan && plan.name && plan.name}
+              titleTypographyProps={{ variant: "h3" }}
+              // subheader="September 14, 2016"
+            />
+            <CardContent>
+              <Grid container spacing={1}>
+                <Grid container item xs={12} spacing={3}>
+                  <Grid item xs={4}>
+                    <Card className={classes.paper} variant="outlined">
+                      <CardHeader
+                        title="Distance"
+                        titleTypographyProps={{ variant: "overline" }}
+                        style={{ paddingBottom: "0px" }}
+                      />
+                      <CardContent>
+                        <Typography variant="h4" component="h4" align="center">
+                          {capitalize(plan.distance)}
+                        </Typography>
+                      </CardContent>
+                    </Card>
+                  </Grid>
+                  <Grid item xs={4}>
+                    <Card className={classes.paper} variant="outlined">
+                      <CardHeader
+                        title="Goal"
+                        titleTypographyProps={{ variant: "overline" }}
+                        style={{ paddingBottom: "0px" }}
+                      />
+                      <CardContent>
+                        <Typography variant="h4" component="h4" align="center">
+                          {capitalize(plan.goal_type)}
+                          {plan.goal_type === enums.GoalType.TIME && (
+                            <Typography
+                              variant="subtitle1"
+                              component="subtitle1"
+                              align="center"
+                            >
+                              {" "}
+                              ({plan.goal_time})
+                            </Typography>
+                          )}
+                        </Typography>
+                      </CardContent>
+                    </Card>
+                  </Grid>
+                  <Grid item xs={4}>
+                    <Card className={classes.paper} variant="outlined">
+                      <CardHeader
+                        title="Runs Per Week"
+                        titleTypographyProps={{ variant: "overline" }}
+                        style={{ paddingBottom: "0px" }}
+                      />
+                      <CardContent>
+                        <Typography variant="h4" component="h4" align="center">
+                          {plan.runs_per_week}
+                        </Typography>
+                      </CardContent>
+                    </Card>
+                  </Grid>
+                </Grid>
+                <Grid container item xs={12} spacing={3}>
+                  <Grid item xs={4}>
+                    <Card className={classes.paper} variant="outlined">
+                      <CardHeader
+                        title="Key Dates"
+                        titleTypographyProps={{ variant: "overline" }}
+                        style={{ paddingBottom: "0px" }}
+                      />
+                      <CardContent>
+                        <Typography variant="h5" component="h5" align="center">
+                          Start:{" "}
+                          {plan.start_date
+                            .toString()
+                            .substring(
+                              0,
+                              plan.start_date.toString().indexOf("T")
+                            )}
+                          <br></br>
+                          Finish:{" "}
+                          {plan.finish_date &&
+                            plan.finish_date
+                              .toString()
+                              .substring(
+                                0,
+                                plan.finish_date.toString().indexOf("T")
+                              )}
+                        </Typography>
+                      </CardContent>
+                    </Card>
+                  </Grid>
+                  <Grid item xs={4}>
+                    <Card className={classes.paper} variant="outlined">
+                      <CardHeader
+                        title="Blocked Days"
+                        titleTypographyProps={{ variant: "overline" }}
+                        style={{ paddingBottom: "0px" }}
+                      />
+                      <CardContent>
+                        {plan.blocked_days.length === 0 && (
+                          <Typography
+                            variant="h4"
+                            component="h4"
+                            align="center"
+                          >
+                            None
+                          </Typography>
+                        )}
+                        {plan.blocked_days.length === 1 && (
+                          <Typography
+                            variant="h4"
+                            component="h4"
+                            align="center"
+                          >
+                            {plan.blocked_days}
+                          </Typography>
+                        )}
+                        {plan.blocked_days.length > 1 && (
+                          <Typography
+                            variant="h6"
+                            component="h6"
+                            align="center"
+                          >
+                            {plan.blocked_days.join(", ")}
+                          </Typography>
+                        )}
+                      </CardContent>
+                    </Card>
+                  </Grid>
+                  <Grid item xs={4}>
+                    <Card className={classes.paper} variant="outlined">
+                      <CardHeader
+                        title="Includes Taper"
+                        titleTypographyProps={{ variant: "overline" }}
+                        style={{ paddingBottom: "0px" }}
+                      />
+                      <CardContent>
+                        <Typography variant="h4" component="h4" align="center">
+                          {plan.include_taper ? "Yes" : "No"}
+                        </Typography>
+                      </CardContent>
+                    </Card>
+                  </Grid>
+                </Grid>
+                <Grid container item xs={12} spacing={3}>
+                  <Grid item xs={4}>
+                    <Card className={classes.paper} variant="outlined">
+                      <CardHeader
+                        title="Includes Cross Training"
+                        titleTypographyProps={{ variant: "overline" }}
+                        style={{ paddingBottom: "0px" }}
+                      />
+                      <CardContent>
+                        <Typography variant="h4" component="h4" align="center">
+                          {plan.include_cross_train ? "Yes" : "No"}
+                        </Typography>
+                      </CardContent>
+                    </Card>
+                  </Grid>
+                  {plan.distance === enums.Distance.HALF_MARATHON ||
+                    (plan.distance === enums.Distance.MARATHON && (
+                      <Grid item xs={4}>
+                        <Card className={classes.paper} variant="outlined">
+                          <CardHeader
+                            title="Long Run Day"
+                            titleTypographyProps={{ variant: "overline" }}
+                            style={{ paddingBottom: "0px" }}
+                          />
+                          <CardContent>
+                            <Typography
+                              variant="h4"
+                              component="h4"
+                              align="center"
+                            >
+                              {plan.long_run_day}
+                            </Typography>
+                          </CardContent>
+                        </Card>
+                      </Grid>
+                    ))}
+                </Grid>
+              </Grid>
+            </CardContent>
+          </Card>
+        )}
+
         <Calendar
-          events={events}
+          events={actEvents}
           startAccessor="start"
           endAccessor="end"
           defaultDate={moment().toDate()}
           localizer={localizer}
           views={["month", "week"]}
-          // popup={true}
-          // components={{
-          //   event: EventComponent
-          // }}
+          onSelectEvent={(event) => onEventSelect(event)}
+          dayPropGetter={customDayPropGetter}
+          eventPropGetter={eventStyleGetter}
+          components={{
+            event: Event,
+          }}
         />
       </div>
-      <Footer />
+
+      {/* <Footer /> */}
+
+      {/* Dialog box for activity */}
+      {selectedActivity && (
+        <Dialog
+          open={selectedActivity}
+          TransitionComponent={Transition}
+          keepMounted
+          onClose={handleActivityClose}
+        >
+          <DialogTitle>
+            <strong>Training Run {selectedActivity.id}</strong>
+            <IconButton
+              aria-label="close"
+              className={classes.closeButton}
+              onClick={handleActivityClose}
+            >
+              <CloseIcon />
+            </IconButton>
+          </DialogTitle>
+          <DialogContent dividers>
+            {selectedActivity.missed && (
+              <Alert severity="error" className={classes.padding}>
+                You missed this activity. Try to keep up with your training plan
+                to give yourself the best chance of completing it!
+              </Alert>
+            )}
+            {selectedActivity.completed && (
+              <Alert severity="success" className={classes.padding}>
+                Well done! You completed this activity!
+              </Alert>
+            )}
+            {!selectedActivity.missed && !selectedActivity.completed && (
+              <Alert severity="info" className={classes.padding}>
+                This is an upcoming event.
+              </Alert>
+            )}
+            <div className={classes.padding}>
+              <strong>Date:</strong>{" "}
+              {selectedActivity.start
+                .toString()
+                .substring(0, selectedActivity.start.indexOf("T"))}
+              <br></br>
+              <strong>Type:</strong> {capitalize(selectedActivity.run_type)} Run
+              <br></br>
+              <strong>Time:</strong> {selectedActivity.time} mins<br></br>
+              <strong>Description:</strong> {selectedActivity.description}
+            </div>
+
+            <MapContainer
+              center={selectedActivity.start_coord}
+              zoom={13}
+              scrollWheelZoom={true}
+            >
+              <TileLayer
+                attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+                url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+              />
+              <Polyline positions={selectedActivity.polyline} color="purple" />
+              <Marker position={selectedActivity.start_coord} title="Start" />
+              <Marker position={selectedActivity.end_coord} title="End" />
+            </MapContainer>
+          </DialogContent>
+        </Dialog>
+      )}
+
+      {/* Dialog box for plan loading */}
+      {loading && (
+        <Dialog open={loading} TransitionComponent={Transition} keepMounted>
+          <DialogTitle>
+            <strong>Gathering your plan information ...</strong>
+          </DialogTitle>
+          <DialogContent>
+            <CircularProgress className={classes.load} />
+          </DialogContent>
+        </Dialog>
+      )}
+
+      {/* Dialog box for plan loading error */}
+      {loadingError && (
+        <Dialog
+          open={loadingError}
+          TransitionComponent={Transition}
+          keepMounted
+        >
+          <DialogTitle>
+            <strong>
+              There was an error gathering your Strava run history.
+            </strong>
+          </DialogTitle>
+          <DialogContent>
+            <LinkRouter
+              to={{
+                pathname: urls.Dashboard,
+              }}
+            >
+              <Button
+                color="secondary"
+                className={classes.error}
+                onClick={onErrorClick}
+              >
+                Return to Dashboard
+              </Button>
+            </LinkRouter>
+          </DialogContent>
+        </Dialog>
+      )}
+
+      {/* Dialog box for plan deletion */}
+      {showDeleteModal && (
+        <Dialog
+          disableBackdropClick
+          disableEscapeKeyDown
+          TransitionComponent={Transition}
+          open={showDeleteModal}
+        >
+          <DialogTitle className={classes.warningColor}>
+            <strong>
+              <WarningRoundedIcon className={classes.icon} />
+              Are you sure you would like to delete this plan?
+            </strong>
+          </DialogTitle>
+          <DialogActions className={classes.warningColor}>
+            <Button autoFocus onClick={handleCancel} color="primary">
+              No
+            </Button>
+            <Button onClick={handleDelete} color="primary">
+              Yes
+            </Button>
+          </DialogActions>
+        </Dialog>
+      )}
     </React.Fragment>
   );
 }

--- a/frontend/src/ViewPlan/ViewPlan.js
+++ b/frontend/src/ViewPlan/ViewPlan.js
@@ -3,8 +3,22 @@ import { Calendar, momentLocalizer } from "react-big-calendar";
 import moment from "moment";
 import "react-big-calendar/lib/css/react-big-calendar.css";
 import Header from "../assets/js/Header";
+import { makeStyles } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
+import Footer from "../assets/js/Footer";
+import * as urls from "../assets/utils/urls";
+import Breadcrumbs from "@material-ui/core/Breadcrumbs";
+import Link from "@material-ui/core/Link";
+import { Link as RouterLink } from "react-router-dom";
 
 const localizer = momentLocalizer(moment);
+
+const useStyles = makeStyles((theme) => ({
+  breadcrumb: {
+    paddingLeft: theme.spacing(2),
+    paddingTop: theme.spacing(1),
+  },
+}));
 
 const now = new Date();
 const events = [
@@ -30,16 +44,37 @@ const events = [
 ];
 
 export default function ViewPlan() {
+  const classes = useStyles();
+  const LinkRouter = (props) => <Link {...props} component={RouterLink} />;
   return (
     <React.Fragment>
       <Header connectToStrava={false} />
-      <div style={{ height: "500pt" }}>
+      <Breadcrumbs
+        className={classes.breadcrumb}
+        style={{ fontSize: 14 }}
+        separator="-"
+      >
+        <LinkRouter
+          color="inherit"
+          to={{
+            pathname: urls.Dashboard,
+            state: { athleteID: sessionStorage.athleteID },
+          }}
+        >
+          Home
+        </LinkRouter>
+        <Typography color="textPrimary" style={{ fontSize: 14 }}>
+          View Plan
+        </Typography>
+      </Breadcrumbs>
+      <div style={{ height: "500pt", marginTop: "10px" }}>
         <Calendar
           events={events}
           startAccessor="start"
           endAccessor="end"
           defaultDate={moment().toDate()}
           localizer={localizer}
+          views={["month", "week"]}
         />
       </div>
     </React.Fragment>

--- a/frontend/src/assets/js/Header.js
+++ b/frontend/src/assets/js/Header.js
@@ -96,6 +96,7 @@ export default function Header({ connectToStrava }) {
             axios
               .post(urls.Athletes, athlete_data, {})
               .then((response) => {
+                sessionStorage.setItem("athleteID", response.data["athlete_id"])
                 setAthleteID(response.data["athlete_id"]);
                 setCredentialsAuthorized(true);
               })
@@ -135,6 +136,8 @@ export default function Header({ connectToStrava }) {
   }
 
   function onLogOutHandler(e) {
+    // clear session storage
+    sessionStorage.clear()
     setLogOut(true);
   }
 
@@ -156,7 +159,6 @@ export default function Header({ connectToStrava }) {
         <Redirect
           to={{
             pathname: urls.Dashboard,
-            state: { athleteID: athleteID },
           }}
         />
       )}

--- a/frontend/src/assets/utils/enums.js
+++ b/frontend/src/assets/utils/enums.js
@@ -23,3 +23,9 @@ export const Day = {
   SATURDAY: "Saturday",
   SUNDAY: "Sunday",
 };
+
+export const EventType = {
+  MILESTONE: "MILESTONE",
+  REST: "REST",
+  ACTIVITY: "ACTIVITY",
+}

--- a/frontend/src/assets/utils/enums.js
+++ b/frontend/src/assets/utils/enums.js
@@ -28,4 +28,4 @@ export const EventType = {
   MILESTONE: "MILESTONE",
   REST: "REST",
   ACTIVITY: "ACTIVITY",
-}
+};

--- a/frontend/src/assets/utils/urls.js
+++ b/frontend/src/assets/utils/urls.js
@@ -15,6 +15,5 @@ export const Dashboard = "/";
 // API URLS
 export const Athletes = "/athletes";
 export const Plans = "/plans";
-export const Plan = "/plan";
 export const StravaInsights = "/strava-insights";
 export const DashboardActivities = "/dashboard";

--- a/frontend/src/assets/utils/urls.js
+++ b/frontend/src/assets/utils/urls.js
@@ -7,6 +7,7 @@ export const StravaToken = "https://www.strava.com/oauth/token";
 export const StravaAuthorization = `https://www.strava.com/oauth/authorize?client_id=52053&redirect_uri=http://localhost:3000/login&response_type=code&scope=activity:read_all`; // TODO: Obtain client details from secure env variables
 
 // Talaria URLs
+export const ViewPlan = "/view-plan"
 export const CreatePlan = "/create-plan";
 export const Login = "/login";
 export const Dashboard = "/";

--- a/frontend/src/assets/utils/urls.js
+++ b/frontend/src/assets/utils/urls.js
@@ -15,5 +15,6 @@ export const Dashboard = "/";
 // API URLS
 export const Athletes = "/athletes";
 export const Plans = "/plans";
+export const Plan = "/plan";
 export const StravaInsights = "/strava-insights";
 export const DashboardActivities = "/dashboard";


### PR DESCRIPTION
This PR will bring in extensive work to the project. It will not only introduce plan generation, but also the view plan functionality.

Here is the changes made:

**Plan Generation:**

- Generating plan name if one is not provided
- Generate plan insights to help with activity generation
- Allocate dates of the activities based off runs per week and blocked days.
- Generate C25K plan if the runner has never ran 5K before

**View Plan:**

- Link to View Plan screen from Dashboard and end of Plan Creation flow
- Loading dialog on loading of plan details
- Ability to view key plan details on ViewPlan page
- Ability to delete Plan on ViewPlan Page
- Ability to return to Dashboard
- react-big-calendar added to allow viewing of activities and rest days
- Colour coordinating completed, missed and upcoming activities
- Outputting Rest or Rest & Cross Training on days off based on plan option
- Ability to click into activities to view their full details
- Ability to view map of completed activity
- Start and Finish events

**Additional Fixes:**

- Using sessionStorage for storing athleteID and planID across the system
- Return to top of screen on Plan submission
- Ordering plans on dashboard by closest finish date
- Outputting message if no plans exist